### PR TITLE
Fix typographical error(s)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -293,7 +293,7 @@ For these features to become avaliable, simply make sure they're installed.
 - `lactate` for static file serving
 
 #### Stylus
-Stylus is compulsary if you're going to bundle css assets; because Stylus can exist as pure css with the benefit of the `@require()` and `@import` bundling syntax. Any plain CSS file is concatenated, it is not resolved to an `@import`.
+Stylus is compulsory if you're going to bundle css assets; because Stylus can exist as pure css with the benefit of the `@require()` and `@import` bundling syntax. Any plain CSS file is concatenated, it is not resolved to an `@import`.
 
 ### Static assets
 Lance handles these mostly automatically:


### PR DESCRIPTION
@nfour, I've corrected a typographical error in the documentation of the [lance](https://github.com/nfour/lance) project. Specifically, I've changed compulsary to compulsory. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
